### PR TITLE
updated old protocol version

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 70810;
+static const int PROTOCOL_VERSION = 70820; // Avoid rejection.
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB


### PR DESCRIPTION
I started a new wallet from scratch to test some other changes and noticed that none of the peers were being accepted but the DNS seeder returned results.  

I found this in the log:
![screen shot 2018-03-26 at 9 12 29 pm](https://user-images.githubusercontent.com/18477105/37946501-8a7ae010-313a-11e8-8a5a-48cdb40d4d22.png)